### PR TITLE
Add parameter pass-in to avoid original attributes loss

### DIFF
--- a/bulma-shortcodes.php
+++ b/bulma-shortcodes.php
@@ -46,7 +46,7 @@ class BulmaShortcodesPlugin
 				add_filter('mce_buttons', array( &$this, 'add_bulma_shortcodes_toolbar_button' ));
 		}
 
-		public function add_bulma_shortcodes_plugin()
+		public function add_bulma_shortcodes_plugin($plugin_array)
 		{
 				$plugin_array['bulma_shortcodes_plugin'] = plugin_dir_url(__FILE__) . "bulma_shortcodes_plugin.js";
 				return $plugin_array;


### PR DESCRIPTION
This bug is cause by the loss of attribute in `$plugin_array` which is used in the `mce_external_plugins` filter hook. The original code don’t care whatever the `$plugin_array` was and just do overwrite.

I find this bug after installing the [Highlighting Code Block](https://tw.wordpress.org/plugins/highlighting-code-block/) plugin. This plugin also calls `mce_external_plugins` filter hook to add a custom button in the TinyMCE toolbar of Classical Editor, but the button disappears when Bulma Shortcodes plugin active. I believe there are other plugins calling the same filter hook, so this fix may help those plugin works normally as they should be.